### PR TITLE
Make the stopping of partition watching a little quieter

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/types/PartitionWatcher.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/types/PartitionWatcher.java
@@ -2,10 +2,11 @@ package com.rackspace.salus.telemetry.presence_monitor.types;
 
 import com.coreos.jetcd.Watch;
 import com.coreos.jetcd.common.exception.ClosedClientException;
+import com.coreos.jetcd.common.exception.ClosedWatcherException;
 import com.coreos.jetcd.watch.WatchResponse;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
-import lombok.Data;
 import java.util.function.BiConsumer;
+import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
@@ -37,7 +38,7 @@ public class PartitionWatcher {
                     if (running) {
                         watchResponseConsumer.accept(watchResponse, partitionSlice);
                     }
-                } catch (ClosedClientException e) {
+                } catch (ClosedClientException|ClosedWatcherException e) {
                     log.debug("Stopping watching of {}", name);
                     return;
                 } catch (InterruptedException e) {


### PR DESCRIPTION
While testing demo scenarios I deleted off the one `/workAllocations/PRESENCE_MONITOR/registry` etcd key that I had and saw the stack trace below. It looks like it's safe to handle that `ClosedWatcherException` as a normal, debug level scenario since the `stop` method had initiated the `watcher.close()` that led to the exception.

```
2018-12-11 15:09:58.839  INFO 58845 --- [pool-1-thread-4] c.r.s.t.p.s.PresenceMonitorProcessor     : Stopping work on id=17188e45-7660-46be-a8ad-2f8a0f0a0223, content={"start":"0000000000000000000000000000000000000000000000000000000000000000","end":"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}
2018-12-11 15:09:58.843 DEBUG 58845 --- [     watchers-3] c.r.s.c.workpart.services.WorkAllocator  : Saw worker=header {
  cluster_id: 2164113787556265017
  member_id: 10602785869456026121
  revision: 2395
  raft_term: 15
}
watch_id: 2
events {
  kv {
    key: "/workAllocations/PRESENCE_MONITOR/workers/48b4dfdd-a892-4158-920a-25b9e96ec0cc"
    create_revision: 2379
    mod_revision: 2395
    version: 3
    value: "0000000000"
    lease: 3029066024878578623
  }
  prev_kv {
    key: "/workAllocations/PRESENCE_MONITOR/workers/48b4dfdd-a892-4158-920a-25b9e96ec0cc"
    create_revision: 2379
    mod_revision: 2381
    version: 2
    value: "0000000001"
    lease: 3029066024878578623
  }
}

2018-12-11 15:09:58.844 DEBUG 58845 --- [     watchers-2] c.r.s.c.workpart.services.WorkAllocator  : Saw active=header {
  cluster_id: 2164113787556265017
  member_id: 10602785869456026121
  revision: 2395
  raft_term: 15
}
watch_id: 1
events {
  type: DELETE
  kv {
    key: "/workAllocations/PRESENCE_MONITOR/active/17188e45-7660-46be-a8ad-2f8a0f0a0223"
    mod_revision: 2395
  }
  prev_kv {
    key: "/workAllocations/PRESENCE_MONITOR/active/17188e45-7660-46be-a8ad-2f8a0f0a0223"
    create_revision: 2381
    mod_revision: 2381
    version: 1
    value: "48b4dfdd-a892-4158-920a-25b9e96ec0cc"
    lease: 3029066024878578623
  }
}

2018-12-11 15:09:58.848  INFO 58845 --- [     watchers-2] c.r.s.c.workpart.services.WorkAllocator  : Observed readyWork=17188e45-7660-46be-a8ad-2f8a0f0a0223 cause=RELEASED rev=2395 allocator=48b4dfdd-a892-4158-920a-25b9e96ec0cc
2018-12-11 15:09:58.864 DEBUG 58845 --- [pool-1-thread-4] c.r.s.c.workpart.services.WorkAllocator  : Skipping least-loaded evaluation since I'm the only worker
2018-12-11 15:09:58.864  INFO 58845 --- [pool-1-thread-4] c.r.s.c.workpart.services.WorkAllocator  : Least loaded, so trying to grab work=17188e45-7660-46be-a8ad-2f8a0f0a0223, ourId=48b4dfdd-a892-4158-920a-25b9e96ec0cc
2018-12-11 15:09:58.866  WARN 58845 --- [     watchers-5] c.r.s.t.p.types.PartitionWatcher         : Failed while watching expected-17188e45-7660-46be-a8ad-2f8a0f0a0223

com.coreos.jetcd.common.exception.ClosedWatcherException: Watcher has been closed
	at com.coreos.jetcd.common.exception.EtcdExceptionFactory.newClosedWatcherException(EtcdExceptionFactory.java:47) ~[jetcd-core-0.0.2.jar:na]
	at com.coreos.jetcd.internal.impl.WatchImpl$WatcherImpl.listen(WatchImpl.java:475) ~[jetcd-core-0.0.2.jar:na]
	at com.rackspace.salus.telemetry.presence_monitor.types.PartitionWatcher.lambda$start$0(PartitionWatcher.java:36) ~[classes/:na]
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-5.0.10.RELEASE.jar:5.0.10.RELEASE]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[na:na]
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264) ~[na:na]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java) ~[na:na]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:834) ~[na:na]
```