### PR TITLE
Small fixes around envoyId assumptions

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessor.java
@@ -97,6 +97,7 @@ public class PresenceMonitorProcessor implements WorkProcessor {
         // Get the expected entries
         GetResponse expectedResponse = envoyResourceManagement.getResourcesInRange(Keys.FMT_RESOURCES_EXPECTED, newSlice.getRangeMin(),
                 newSlice.getRangeMax()).join();
+        log.debug("Found {} expected envoys", expectedResponse.getCount());
         expectedResponse.getKvs().forEach(kv -> {
             // Create an entry for the kv
             String k = getExpectedId(kv);


### PR DESCRIPTION
Some of this will change further once we move towards SQL for storing various data.

I had to make these changes for the presence service to start for me with the data that was in my etcd.  Only really two changes:

1. envoyId will not be stored as part of the `expected` resources, only the `active`.  Currently it is there if the resource is created by the envoy attachment but not via the API creation.
   * This is mostly due to us using the same model for both keys right now.  SQL will change that and the envoyId will never be included.
2. If an envoyId is not available you cannot look up the labels via the `FMT_ENVOYS_BY_ID` key.  Also, we don't need to do that look up because the labels are already stored in the `ResourceInfo`
   * With SQL the labels will still be retrieved along with the expected resources.
