### PR TITLE
Reference new salus-telemetry-protocol module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
         </dependency>
         <dependency>
             <groupId>com.rackspace.salus</groupId>
+            <artifactId>salus-telemetry-protocol</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.rackspace.salus</groupId>
             <artifactId>salus-telemetry-etcd-adapter</artifactId>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>


### PR DESCRIPTION
# What

Add dependency on new protocol module for gRPC and Avro related classes.

Follow up of https://github.com/racker/salus-telemetry-protocol/pull/1