### PR TITLE
Adjust unit tests for upgrading to Spring Boot 2.1.2

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/DefaultTimestampProviderImpl.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/DefaultTimestampProviderImpl.java
@@ -1,0 +1,13 @@
+package com.rackspace.salus.telemetry.presence_monitor.services;
+
+import java.time.Instant;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultTimestampProviderImpl implements TimestampProvider {
+
+  @Override
+  public Instant getCurrentInstant() {
+    return Instant.ofEpochMilli(System.currentTimeMillis());
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/TimestampProvider.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/TimestampProvider.java
@@ -1,0 +1,7 @@
+package com.rackspace.salus.telemetry.presence_monitor.services;
+
+import java.time.Instant;
+
+public interface TimestampProvider {
+  Instant getCurrentInstant();
+}

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/types/PartitionWatcher.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/types/PartitionWatcher.java
@@ -9,11 +9,9 @@ import java.util.function.BiConsumer;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.stereotype.Component;
 
 @Data
 @Slf4j
-@Component
 public class PartitionWatcher {
     final String name;
     final ThreadPoolTaskScheduler taskScheduler;


### PR DESCRIPTION
# Resolves

SALUS-145

# What

Spring Boot 2.1.x was a little bit pickier about things, so there were some fixes I had make to unit tests during the 2.1.2 upgrade. My `TimestampProvider` additions were probably overkill for an existing assertion mismatch I noticed while re-running tests, but regardless it's a nice convention that I use elsewhere to ensure stable timestamp during unit tests. 

## How to test

Via unit tests