### PR TITLE
Switch to common KafkaTopicProperties

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/PresenceMonitorApplication.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/PresenceMonitorApplication.java
@@ -1,9 +1,27 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.telemetry.presence_monitor;
 
+import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@EnableSalusKafkaMessaging
 public class PresenceMonitorApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/config/PresenceMonitorProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/config/PresenceMonitorProperties.java
@@ -16,10 +16,8 @@
 
 package com.rackspace.salus.telemetry.presence_monitor.config;
 
-import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.Map;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.convert.DurationUnit;
@@ -29,7 +27,6 @@ import org.springframework.stereotype.Component;
 @Component
 @Data
 public class PresenceMonitorProperties {
-    Map<KafkaMessageType, String> kafkaTopics;
     @DurationUnit(ChronoUnit.SECONDS)
     Duration exportPeriod = Duration.ofSeconds(60);
     String resourceManagerUrl;

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/config/ResourceListenerConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/config/ResourceListenerConfig.java
@@ -1,30 +1,28 @@
 /*
- *    Copyright 2019 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.presence_monitor.config;
 
 
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.presence_monitor.services.ResourceListener;
 import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.concurrent.ConcurrentHashMap;
 
 
 @Configuration
@@ -35,7 +33,7 @@ public class ResourceListenerConfig {
     }
 
     @Bean
-    public ResourceListener resourceListener() {
-        return new ResourceListener(getPartitionTable());
+    public ResourceListener resourceListener(KafkaTopicProperties kafkaTopicProperties) {
+        return new ResourceListener(getPartitionTable(), kafkaTopicProperties);
     }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/KafkaEgress.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/KafkaEgress.java
@@ -1,24 +1,22 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.presence_monitor.services;
 
-import com.rackspace.salus.telemetry.presence_monitor.config.PresenceMonitorProperties;
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -28,16 +26,27 @@ import org.springframework.stereotype.Service;
 public class KafkaEgress {
 
     private final KafkaTemplate kafkaTemplate;
-    private final PresenceMonitorProperties presenceMonitorProperties;
+    private final KafkaTopicProperties kafkaTopicProperties;
 
     @Autowired
-    public KafkaEgress(KafkaTemplate kafkaTemplate, PresenceMonitorProperties presenceMonitorProperties) {
+    public KafkaEgress(KafkaTemplate kafkaTemplate, KafkaTopicProperties kafkaTopicProperties) {
         this.kafkaTemplate = kafkaTemplate;
-        this.presenceMonitorProperties = presenceMonitorProperties;
+        this.kafkaTopicProperties = kafkaTopicProperties;
     }
 
     public void send(String tenantId, KafkaMessageType messageType, String payload) {
-        final String topic = presenceMonitorProperties.getKafkaTopics().get(messageType);
+        final String topic;
+        switch (messageType) {
+            case METRIC:
+                topic = kafkaTopicProperties.getMetrics();
+                break;
+            case EVENT:
+                topic = kafkaTopicProperties.getEvents();
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported messageType: " + messageType);
+        }
+
         if (topic == null) {
             throw new IllegalArgumentException(String.format("No topic configured for %s", messageType));
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,4 @@
 presence-monitor:
-  kafka-topics:
-    LOG:
-      telemetry.logs.json
-    METRIC:
-      telemetry.metrics.json
-    EVENT:
-      telemetry.events.json
-    RESOURCE:
-      telemetry.resources.json
   exportPeriod:
     5
   resourceManagerUrl:


### PR DESCRIPTION
# Resolves

Discovered during SALUS-129

# What

Rather than make each application do it's own definition of kafka topic configuration, we can use a common declaration and reasonable defaults for those topics.

# How

Switch over to using `KafkaTopicProperties` with the module enabled.

## How to test

Unit tests cover the kafka integration and context loading nicely.