### PR TITLE
fix kafka config

### DIFF
--- a/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/ResourceListenerTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/ResourceListenerTest.java
@@ -36,7 +36,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;

--- a/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/ResourceListenerTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/ResourceListenerTest.java
@@ -37,9 +37,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.MessageListenerContainer;
@@ -51,7 +53,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@EnableAutoConfiguration
+@Import({KafkaAutoConfiguration.class})
 @EnableSalusKafkaMessaging
 @DirtiesContext
 @Slf4j


### PR DESCRIPTION
The tests was using the EnableAutoConfiguration annotation, which attempted to configure jdbc unnecessarily and fail.  What was needed was just to enable the autoconfig of kafka, so I reduced the scope of the autoconfig to just kafka.
