### PR TITLE
Switch over to umb-protocol for ExternalMetric

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
             <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rackspace.salus</groupId>
-            <artifactId>salus-telemetry-protocol</artifactId>
+            <groupId>com.rackspace.monplat</groupId>
+            <artifactId>umb-protocol</artifactId>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/MetricRouter.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/MetricRouter.java
@@ -20,11 +20,11 @@ package com.rackspace.salus.telemetry.presence_monitor.services;
 
 import com.coreos.jetcd.Client;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rackspace.salus.model.AccountType;
-import com.rackspace.salus.model.ExternalMetric;
-import com.rackspace.salus.model.MonitoringSystem;
-import com.rackspace.salus.telemetry.model.ResourceInfo;
+import com.rackspace.monplat.protocol.AccountType;
+import com.rackspace.monplat.protocol.ExternalMetric;
+import com.rackspace.monplat.protocol.MonitoringSystem;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
+import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;


### PR DESCRIPTION
# What

While building my local workspace I was reminded that due to https://github.com/racker/salus-telemetry-protocol/pull/5 , this module also needed to switch over to umb-protocol.

## How to test

Existing unit tests