### PR TITLE
Use resource API & other tweaks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.rackspace.salus</groupId>
+            <artifactId>salus-telemetry-resource-management</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <classifier>client</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.rackspace.monplat</groupId>
             <artifactId>umb-protocol</artifactId>
             <version>0.1.0-SNAPSHOT</version>

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/PresenceMonitorApplication.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/PresenceMonitorApplication.java
@@ -17,12 +17,21 @@
 package com.rackspace.salus.telemetry.presence_monitor;
 
 import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
+import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import java.util.concurrent.ConcurrentHashMap;
 
 @SpringBootApplication
 @EnableSalusKafkaMessaging
 public class PresenceMonitorApplication {
+
+	@Bean
+	public ConcurrentHashMap<String, PartitionSlice> partitionTable() {
+		return new ConcurrentHashMap<>();
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(PresenceMonitorApplication.class, args);

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/config/RestClientsConfig.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/config/RestClientsConfig.java
@@ -16,27 +16,32 @@
 
 package com.rackspace.salus.telemetry.presence_monitor.config;
 
-
-import com.rackspace.salus.common.messaging.KafkaTopicProperties;
-import com.rackspace.salus.telemetry.presence_monitor.services.ResourceListener;
-import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;
-import java.util.concurrent.ConcurrentHashMap;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.resource_management.web.client.ResourceApiClient;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-
 @Configuration
-public class ResourceListenerConfig {
-    @Bean
-    public ConcurrentHashMap<String, PartitionSlice> getPartitionTable() {
-        return new ConcurrentHashMap<>();
-    }
+public class RestClientsConfig {
 
-    @Bean
-    public ResourceListener resourceListener(KafkaTopicProperties kafkaTopicProperties,
-                                             RestTemplateBuilder restTemplateBuilder, PresenceMonitorProperties props) {
-        return new ResourceListener(getPartitionTable(), kafkaTopicProperties, restTemplateBuilder, props);
-    }
+  private final ObjectMapper objectMapper;
+  private final ServicesProperties servicesProperties;
+
+  @Autowired
+  public RestClientsConfig(ObjectMapper objectMapper, ServicesProperties servicesProperties) {
+    this.objectMapper = objectMapper;
+    this.servicesProperties = servicesProperties;
+  }
+
+  @Bean
+  public ResourceApi resourceApi(RestTemplateBuilder restTemplateBuilder) {
+    return new ResourceApiClient(objectMapper,
+            restTemplateBuilder
+            .rootUri(servicesProperties.getResourceManagementUrl())
+            .build()
+    );
+  }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/config/ServicesProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/config/ServicesProperties.java
@@ -16,17 +16,13 @@
 
 package com.rackspace.salus.telemetry.presence_monitor.config;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.convert.DurationUnit;
 import org.springframework.stereotype.Component;
 
-@ConfigurationProperties("presence-monitor")
+@ConfigurationProperties("services")
 @Component
 @Data
-public class PresenceMonitorProperties {
-    @DurationUnit(ChronoUnit.SECONDS)
-    Duration exportPeriod = Duration.ofSeconds(60);
+public class ServicesProperties {
+  String resourceManagementUrl;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessor.java
@@ -120,12 +120,10 @@ public class PresenceMonitorProcessor implements WorkProcessor {
     }
 
     private List<Resource> getResources() {
-        List<Resource> resources;
         // Stop the resourceListener while reading from the resource manager
         synchronized (resourceListener) {
-            resources = resourceApi.getExpectedEnvoys();
+            return resourceApi.getExpectedEnvoys();
         }
-        return resources;
     }
 
     static ResourceInfo convert(Resource resource) {
@@ -285,6 +283,4 @@ public class PresenceMonitorProcessor implements WorkProcessor {
     public ConcurrentHashMap<String, PartitionSlice> getPartitionTable() {
         return partitionTable;
     }
-
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,11 +26,3 @@ spring:
   main:
     web-environment:
       false
-
----
-
-spring:
-  profiles: test
-presence-monitor:
-  exportPeriod:
-    1

--- a/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessorTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessorTest.java
@@ -28,61 +28,74 @@ import com.coreos.jetcd.data.ByteSequence;
 import com.coreos.jetcd.watch.WatchResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.common.util.KeyHashing;
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import com.rackspace.salus.telemetry.model.Resource;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.presence_monitor.config.PresenceMonitorProperties;
-import com.rackspace.salus.telemetry.presence_monitor.config.ResourceListenerConfig;
 import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;
 import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.web.client.ResponseExtractor;
-import org.springframework.web.client.RestTemplate;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest
+@EmbeddedKafka(partitions = 1, topics = {PresenceMonitorProcessorTest.TOPIC_METRICS})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @EnableSalusKafkaMessaging
 public class PresenceMonitorProcessorTest {
-    @Configuration
-    @Import({KeyHashing.class, MetricExporter.class, PresenceMonitorProperties.class, ResourceListenerConfig.class})
+
+    public static final String TOPIC_METRICS = "test.metrics.json";
+
+    // Declare our own unit test Spring config, which is merged with the main app config.
+    @TestConfiguration
     public static class TestConfig {
+
+        // Adjust our standard topic properties to point metrics at our test topic
         @Bean
-        MeterRegistry getMeterRegistry() {
-            return new SimpleMeterRegistry();
+        public KafkaTopicProperties kafkaTopicProperties() {
+            final KafkaTopicProperties properties = new KafkaTopicProperties();
+            properties.setMetrics(TOPIC_METRICS);
+            return properties;
+        }
+
+        @Bean
+        @Primary // This overrides any existing Client bean with this bean.
+        public Client client() {
+            final List<String> endpoints = etcd.cluster().getClientEndpoints().stream()
+                    .map(URI::toString)
+                    .collect(Collectors.toList());
+            return com.coreos.jetcd.Client.builder().endpoints(endpoints).build();
         }
     }
 
-    @Rule
-    public final EtcdClusterResource etcd = new EtcdClusterResource("PresenceMonitorProcessorTest", 1);
+    @ClassRule
+    public static final EtcdClusterResource etcd = new EtcdClusterResource("PresenceMonitorProcessorTest", 1);
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -95,20 +108,15 @@ public class PresenceMonitorProcessorTest {
     @Autowired
     SimpleMeterRegistry simpleMeterRegistry;
 
+    @Autowired
+    KeyHashing hashing;
+
     private ThreadPoolTaskScheduler taskScheduler;
 
     private EnvoyResourceManagement envoyResourceManagement;
 
-    private Client client;
-
     @Autowired
-    KeyHashing hashing;
-
-    @Mock
-    RestTemplate restTemplate;
-
-    @MockBean
-    RestTemplateBuilder restTemplateBuilder;
+    private Client client;
 
     private String expectedResourceString =
             "{\"resourceId\":\"os:LINUX\"," +
@@ -117,6 +125,8 @@ public class PresenceMonitorProcessorTest {
                     "\"tenantId\":\"123456\"}";
 
     private String activeResourceInfoString;
+
+    private Resource expectedResource;
 
     private ResourceInfo expectedResourceInfo;
 
@@ -128,15 +138,15 @@ public class PresenceMonitorProcessorTest {
     @Autowired
     private PresenceMonitorProperties presenceMonitorProperties;
 
+    @Mock
+    ResourceApi resourceApi;
+
     @Autowired
     ConcurrentHashMap<String, PartitionSlice> partitionTable;
 
     @Autowired
     @Qualifier("resourceListener")
     ResourceListener resourceListener;
-
-    @Mock
-    ClientHttpResponse response;
 
     @Before
     public void setUp() throws Exception {
@@ -145,18 +155,12 @@ public class PresenceMonitorProcessorTest {
         taskScheduler.setThreadNamePrefix("tasks-");
         taskScheduler.initialize();
 
-        final List<String> endpoints = etcd.cluster().getClientEndpoints().stream()
-                .map(URI::toString)
-                .collect(Collectors.toList());
-        client = com.coreos.jetcd.Client.builder().endpoints(endpoints).build();
-
         envoyResourceManagement = new EnvoyResourceManagement(client, objectMapper, hashing);
-        Resource expectedResource = objectMapper.readValue(expectedResourceString, Resource.class);
+        expectedResource = objectMapper.readValue(expectedResourceString, Resource.class);
         expectedResourceInfo = PresenceMonitorProcessor.convert(expectedResource);
         activeResourceInfoString = objectMapper.writeValueAsString(expectedResourceInfo).replace("X86_64", "X86_32");
 
         activeResourceInfo = objectMapper.readValue(activeResourceInfoString, ResourceInfo.class);
-        when(restTemplateBuilder.build()).thenReturn(restTemplate);
     }
 
 
@@ -164,12 +168,7 @@ public class PresenceMonitorProcessorTest {
     public void testProcessorStart() throws Exception {
         MetricExporter metricExporter = new MetricExporter(metricRouter, presenceMonitorProperties, simpleMeterRegistry);
 
-        InputStream testStream = new ByteArrayInputStream((PresenceMonitorProcessor.SSEHdr + " " + expectedResourceString + "\n\n").getBytes());
-        when(response.getBody()).thenReturn(testStream);
-        doAnswer(invocation -> {
-            ResponseExtractor<InputStream> responseExtractor = invocation.getArgument(3);
-            return responseExtractor.extractData(response);
-        }).when(restTemplate).execute(any(), any(), any(), any(), (Object) any());
+        when(resourceApi.getExpectedEnvoys()).thenReturn(Collections.singletonList(expectedResource));
 
         Semaphore routerSem = new Semaphore(0);
         doAnswer((a) -> {
@@ -179,7 +178,7 @@ public class PresenceMonitorProcessorTest {
 
         PresenceMonitorProcessor p = new PresenceMonitorProcessor(client, objectMapper,
                 envoyResourceManagement, taskScheduler, metricExporter,
-                simpleMeterRegistry, presenceMonitorProperties, restTemplateBuilder, resourceListener, partitionTable);
+                simpleMeterRegistry, resourceListener, partitionTable, resourceApi);
 
         String expectedId = PresenceMonitorProcessor.genExpectedId(expectedResourceInfo.getTenantId(),
                 expectedResourceInfo.getResourceId());
@@ -214,17 +213,9 @@ public class PresenceMonitorProcessorTest {
         doNothing().when(metricRouter).route(any(), any());
 
         MetricExporter metricExporter = new MetricExporter(metricRouter, presenceMonitorProperties, simpleMeterRegistry);
-        InputStream testStream = new ByteArrayInputStream(("\n\n").getBytes());
-        when(response.getBody()).thenReturn(testStream);
-        doAnswer(invocation -> {
-            ResponseExtractor<InputStream> responseExtractor = invocation.getArgument(3);
-            return responseExtractor.extractData(response);
-        }).when(restTemplate).execute(any(), any(), any(), any(), (Object) any());
-
         PresenceMonitorProcessor p = new PresenceMonitorProcessor(client, objectMapper,
                 envoyResourceManagement, taskScheduler, metricExporter,
-                new SimpleMeterRegistry(), presenceMonitorProperties, restTemplateBuilder, resourceListener, partitionTable);
-
+                new SimpleMeterRegistry(), resourceListener, partitionTable, resourceApi);
 
         // wrap active watch consumer to release a semaphore when done
         Semaphore activeSem = new Semaphore(0);
@@ -234,7 +225,6 @@ public class PresenceMonitorProcessorTest {
             activeSem.release();
         };
         p.setActiveWatchResponseConsumer(newActiveConsumer);
-
 
         p.start("id1", "{" +
                 "\"start\":\"" + rangeStart + "\"," +
@@ -267,6 +257,5 @@ public class PresenceMonitorProcessorTest {
                 partitionSlice.getExpectedTable().get(activeId).getActive(), false);
         assertEquals(activeResourceInfo,
                 partitionSlice.getExpectedTable().get(activeId).getResourceInfo());
-
     }
 }

--- a/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessorTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessorTest.java
@@ -85,7 +85,7 @@ public class PresenceMonitorProcessorTest {
         }
 
         @Bean
-        @Primary // This overrides any existing Client bean with this bean.
+        @Primary // Gives preference to this bean if other Client beans are configured
         public Client client() {
             final List<String> endpoints = etcd.cluster().getClientEndpoints().stream()
                     .map(URI::toString)

--- a/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/ResourceListenerTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/ResourceListenerTest.java
@@ -19,9 +19,9 @@ package com.rackspace.salus.telemetry.presence_monitor.services;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.common.util.KeyHashing;
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.Resource;
-import com.rackspace.salus.telemetry.presence_monitor.config.PresenceMonitorProperties;
 import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -29,46 +29,26 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @Slf4j
-@Import({PresenceMonitorProperties.class})
 @ActiveProfiles("test")
 public class ResourceListenerTest {
     private KeyHashing hashing = new KeyHashing();
 
     private static String sliceKey = "id1";
 
-    @MockBean
-    RestTemplateBuilder restTemplateBuilder;
-
     @Mock
-    RestTemplate restTemplate;
-
-    @Mock
-    ResponseEntity<Resource> responseEntity;
-
-    @Autowired
-    PresenceMonitorProperties props;
+    ResourceApi resourceApi;
 
     private static ConcurrentHashMap<String, PartitionSlice>
             partitionTable;
@@ -106,28 +86,26 @@ public class ResourceListenerTest {
     public void testListener() {
         String key = String.format("%s:%s", tenantId, resourceId);
         String hash = hashing.hash(key);
-        when(restTemplateBuilder.build()).thenReturn(restTemplate);
-        when(restTemplate.getForEntity(anyString(),any(), (Map)any())).thenReturn(responseEntity);
-        when(responseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
-        when(responseEntity.getBody()).thenReturn(resource);
 
-
-        ResourceListener rl = new ResourceListener(partitionTable, new KafkaTopicProperties(), restTemplateBuilder, props);
+        ResourceListener rl = new ResourceListener(partitionTable, new KafkaTopicProperties(), resourceApi);
         ConsumerRecord<String, ResourceEvent> cr = new ConsumerRecord<>("http://dummy", 0, 0, key, resourceEvent);
-        // send the message
         assertNull("Confirm no entry", partitionTable.get(sliceKey).getExpectedTable().get(hash));
-        rl.resourceListener(cr);
+
+        // send the initial message
+        when(resourceApi.getByResourceId(any(), any())).thenReturn(resource);
+        rl.handleResourceEvent(cr);
         PartitionSlice.ExpectedEntry entry = partitionTable.get(sliceKey).getExpectedTable().get(hash);
         assertEquals("Confirm new entry", entry.getResourceInfo(), PresenceMonitorProcessor.convert(resource));
 
-        when(responseEntity.getBody()).thenReturn(updatedResource);
-        rl.resourceListener(cr);
+        // send a resource event due to an update to the resource
+        when(resourceApi.getByResourceId(any(), any())).thenReturn(updatedResource);
+        rl.handleResourceEvent(cr);
         entry = partitionTable.get(sliceKey).getExpectedTable().get(hash);
         assertEquals("Confirm updated entry", entry.getResourceInfo(), PresenceMonitorProcessor.convert(updatedResource));
 
         // Throwing not found exception should be interpreted as the resource should be deleted
-        when(restTemplate.getForEntity(anyString(),any(), (Map)any())).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
-        rl.resourceListener(cr);
+        when(resourceApi.getByResourceId(any(), any())).thenReturn(null);
+        rl.handleResourceEvent(cr);
         assertNull("Confirm deleted entry", partitionTable.get(sliceKey).getExpectedTable().get(hash));
     }
 

--- a/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/ResourceListenerTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/ResourceListenerTest.java
@@ -23,15 +23,12 @@ import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.Resource;
 import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
-
+import org.mockito.junit.MockitoJUnitRunner;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -39,9 +36,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
-@Slf4j
-@ActiveProfiles("test")
+@RunWith(MockitoJUnitRunner.class)
 public class ResourceListenerTest {
     private KeyHashing hashing = new KeyHashing();
 
@@ -108,5 +103,4 @@ public class ResourceListenerTest {
         rl.handleResourceEvent(cr);
         assertNull("Confirm deleted entry", partitionTable.get(sliceKey).getExpectedTable().get(hash));
     }
-
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,3 +5,6 @@ spring:
     bootstrap-servers: ${spring.embedded.kafka.brokers}
     consumer:
       group-id: presence-monitor-${random.value}
+presence-monitor:
+  exportPeriod:
+    1

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  application:
+    name: presence-monitor-tests
+  kafka:
+    bootstrap-servers: ${spring.embedded.kafka.brokers}
+    consumer:
+      group-id: presence-monitor-${random.value}


### PR DESCRIPTION
# What

Rather than writing out all the API requests, this now pulls in the resource api client to lessen the amount of work needed for all those requests.

This also switches over the tests to utilize EmbeddedKafka.

Various other tweaks are in here too, mostly based on the comments from the reviews in https://github.com/racker/salus-telemetry-presence-monitor/pull/25

## How to test

When combined with https://github.com/racker/salus-telemetry-resource-management/pull/22 all tests can be run successfully without requiring any docker dev things to be running.

# Why

To improve the readability of the code and make it less complex to interact with.

# Note

After coming back to this after the weekend I kinda forgot what else I had planned for this, but the changes here should hit most if not all of what I wanted to change.