### PR TITLE
Use ResourceDTO instead of Resource

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessor.java
@@ -32,7 +32,6 @@ import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.etcd.types.Keys;
-import com.rackspace.salus.resource_management.entities.Resource;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessor.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessor.java
@@ -29,11 +29,11 @@ import com.rackspace.salus.common.util.KeyHashing;
 import com.rackspace.salus.common.workpart.Bits;
 import com.rackspace.salus.common.workpart.WorkProcessor;
 import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.etcd.types.Keys;
-import com.rackspace.salus.telemetry.model.Resource;
+import com.rackspace.salus.resource_management.entities.Resource;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
-import com.rackspace.salus.telemetry.presence_monitor.config.PresenceMonitorProperties;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
 import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;
 import com.rackspace.salus.telemetry.presence_monitor.types.PartitionWatcher;
@@ -43,16 +43,10 @@ import io.micrometer.core.instrument.Tag;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.context.annotation.Bean;
-import org.springframework.http.HttpMethod;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -119,14 +113,14 @@ public class PresenceMonitorProcessor implements WorkProcessor {
                 (expectedId.compareTo(slice.getRangeMax()) <= 0));
     }
 
-    private List<Resource> getResources() {
+    private List<ResourceDTO> getResources() {
         // Stop the resourceListener while reading from the resource manager
         synchronized (resourceListener) {
             return resourceApi.getExpectedEnvoys();
         }
     }
 
-    static ResourceInfo convert(Resource resource) {
+    static ResourceInfo convert(ResourceDTO resource) {
         if (resource == null) {
             return null;
         }
@@ -163,7 +157,7 @@ public class PresenceMonitorProcessor implements WorkProcessor {
         newSlice.setRangeMin(workContent.get("start").asText());
 
         // Get the expected entries
-        List<Resource> resources = getResources();
+        List<ResourceDTO> resources = getResources();
 
         log.debug("Found {} expected envoys", resources.size());
         resources.forEach(resource -> {

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/ResourceListener.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/ResourceListener.java
@@ -18,8 +18,8 @@ package com.rackspace.salus.telemetry.presence_monitor.services;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
-import com.rackspace.salus.telemetry.model.Resource;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;
 
@@ -57,7 +57,7 @@ public class ResourceListener implements ConsumerSeekAware {
     @KafkaListener(topics = "#{__listener.topic}")
     public void handleResourceEvent(ConsumerRecord<String, ResourceEvent> record) {
         ResourceEvent event = record.value();
-        Resource resource = resourceApi.getByResourceId(event.getTenantId(), event.getResourceId());
+        ResourceDTO resource = resourceApi.getByResourceId(event.getTenantId(), event.getResourceId());
         ResourceInfo rinfo = PresenceMonitorProcessor.convert(resource);
 
         String hash = PresenceMonitorProcessor.genExpectedId(event.getTenantId(), event.getResourceId());
@@ -77,7 +77,7 @@ public class ResourceListener implements ConsumerSeekAware {
     }
 
     // synchronized to prevent slice from being updated simultaneously when a new slice is added
-    synchronized void updateSlice(PartitionSlice slice, String key, Resource resource, ResourceInfo rinfo) {
+    synchronized void updateSlice(PartitionSlice slice, String key, ResourceDTO resource, ResourceInfo rinfo) {
         if (resource != null && resource.getPresenceMonitoringEnabled()) {
             PartitionSlice.ExpectedEntry newEntry = new PartitionSlice.ExpectedEntry();
             PartitionSlice.ExpectedEntry oldEntry = slice.getExpectedTable().get(key);

--- a/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessorTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/PresenceMonitorProcessorTest.java
@@ -31,9 +31,9 @@ import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.common.util.KeyHashing;
 import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
-import com.rackspace.salus.telemetry.model.Resource;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.presence_monitor.config.PresenceMonitorProperties;
 import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;
@@ -126,7 +126,7 @@ public class PresenceMonitorProcessorTest {
 
     private String activeResourceInfoString;
 
-    private Resource expectedResource;
+    private ResourceDTO expectedResource;
 
     private ResourceInfo expectedResourceInfo;
 
@@ -156,7 +156,7 @@ public class PresenceMonitorProcessorTest {
         taskScheduler.initialize();
 
         envoyResourceManagement = new EnvoyResourceManagement(client, objectMapper, hashing);
-        expectedResource = objectMapper.readValue(expectedResourceString, Resource.class);
+        expectedResource = objectMapper.readValue(expectedResourceString, ResourceDTO.class);
         expectedResourceInfo = PresenceMonitorProcessor.convert(expectedResource);
         activeResourceInfoString = objectMapper.writeValueAsString(expectedResourceInfo).replace("X86_64", "X86_32");
 

--- a/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/ResourceListenerTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/ResourceListenerTest.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.common.util.KeyHashing;
 import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
-import com.rackspace.salus.telemetry.model.Resource;
 import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Before;
@@ -60,7 +60,7 @@ public class ResourceListenerTest {
 
     private ResourceEvent resourceEvent = new ResourceEvent();
 
-    private Resource resource, updatedResource;
+    private ResourceDTO resource, updatedResource;
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Before
@@ -72,8 +72,8 @@ public class ResourceListenerTest {
         slice.setRangeMin(rangeStart);
         slice.setRangeMax(rangeEnd);
         partitionTable.put(sliceKey, slice);
-        resource = objectMapper.readValue(resourceString, Resource.class);
-        updatedResource = objectMapper.readValue(updatedResourceString, Resource.class);
+        resource = objectMapper.readValue(resourceString, ResourceDTO.class);
+        updatedResource = objectMapper.readValue(updatedResourceString, ResourceDTO.class);
         resourceEvent.setResourceId(resourceId).setTenantId(tenantId);
     }
 


### PR DESCRIPTION
# What

1. Updates to use `ResourceDTO` instead of `Resource`

# How

1. Search and Replace mostly.

## How to test

Existing tests

# Why

1. The resource api changed in https://github.com/racker/salus-telemetry-resource-management/pull/33