### PR TITLE
catching jdbc and kafka exceptions

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/KafkaEgress.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/KafkaEgress.java
@@ -54,9 +54,7 @@ public class KafkaEgress {
         }
         try {
             kafkaTemplate.send(topic, tenantId, payload).get();
-        } catch (InterruptedException e) {
-            throw new RuntimeKafkaException(e);
-        } catch (ExecutionException e) {
+        } catch (InterruptedException|ExecutionException e) {
             throw new RuntimeKafkaException(e);
         }
     }

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/KafkaEgress.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/KafkaEgress.java
@@ -16,8 +16,10 @@
 
 package com.rackspace.salus.telemetry.presence_monitor.services;
 
+import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.KafkaMessageType;
+import java.util.concurrent.ExecutionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
@@ -50,6 +52,12 @@ public class KafkaEgress {
         if (topic == null) {
             throw new IllegalArgumentException(String.format("No topic configured for %s", messageType));
         }
-        kafkaTemplate.send(topic, tenantId, payload);
+        try {
+            kafkaTemplate.send(topic, tenantId, payload).get();
+        } catch (InterruptedException e) {
+            throw new RuntimeKafkaException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeKafkaException(e);
+        }
     }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/RestExceptionHandler.java
@@ -47,12 +47,12 @@ public class RestExceptionHandler extends
   @ExceptionHandler({JDBCException.class})
   public ResponseEntity<?> handleJDBCException(
       HttpServletRequest request) {
-    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.jdbcExceptionMessage);
+    return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.jdbcExceptionMessage);
   }
 
   @ExceptionHandler({RuntimeKafkaException.class})
   public ResponseEntity<?> handleKafkaExceptions(
       HttpServletRequest request) {
-    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.kafkaExceptionMessage);
+    return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.kafkaExceptionMessage);
   }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/RestExceptionHandler.java
@@ -16,7 +16,10 @@
 
 package com.rackspace.salus.telemetry.presence_monitor.web.controller;
 
+import com.rackspace.salus.common.errors.ResponseMessages;
+import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import javax.servlet.http.HttpServletRequest;
+import org.hibernate.JDBCException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
@@ -39,5 +42,17 @@ public class RestExceptionHandler extends
   public ResponseEntity<?> handleBadRequest(
       HttpServletRequest request) {
     return respondWith(request, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler({JDBCException.class})
+  public ResponseEntity<?> handleJDBCException(
+      HttpServletRequest request) {
+    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.jdbcExceptionMessage);
+  }
+
+  @ExceptionHandler({RuntimeKafkaException.class})
+  public ResponseEntity<?> handleKafkaExceptions(
+      HttpServletRequest request) {
+    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.kafkaExceptionMessage);
   }
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-433

# What

This PR is trying to catch the error when the API nodes are up but a service behind the API node isn't. 

# How

I am catching the particular error that gets thrown when another service isn't running. 

## How to test

Start this service after starting all of the docker containers. 
After this has started shut down mysql.
Send a creation request in.
Bring mysql back up and shut down kafka.
send the same creation request.

# Why

For unknown reasons Spring Boot doesn't seem to appreciate using the configuration options for not including the exception or the stack trace.

Instead I decided to utilize the pattern we are already using for catching exceptions and responding with HTTP status codes to give a friendly message.