### PR TITLE
fix exc handlers

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/RestExceptionHandler.java
@@ -37,16 +37,10 @@ public class RestExceptionHandler extends
   public RestExceptionHandler(ErrorAttributes errorAttributes) {
     super(errorAttributes);
   }
-  
+
   @ExceptionHandler({JDBCException.class})
   public ResponseEntity<?> handleJDBCException(
       HttpServletRequest request) {
     return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.jdbcExceptionMessage);
-  }
-
-  @ExceptionHandler({RuntimeKafkaException.class})
-  public ResponseEntity<?> handleKafkaExceptions(
-      HttpServletRequest request) {
-    return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.kafkaExceptionMessage);
   }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/RestExceptionHandler.java
@@ -17,7 +17,6 @@
 package com.rackspace.salus.telemetry.presence_monitor.web.controller;
 
 import com.rackspace.salus.common.errors.ResponseMessages;
-import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import javax.servlet.http.HttpServletRequest;
 import org.hibernate.JDBCException;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/RestExceptionHandler.java
@@ -37,13 +37,7 @@ public class RestExceptionHandler extends
   public RestExceptionHandler(ErrorAttributes errorAttributes) {
     super(errorAttributes);
   }
-
-  @ExceptionHandler({IllegalArgumentException.class})
-  public ResponseEntity<?> handleBadRequest(
-      HttpServletRequest request) {
-    return respondWith(request, HttpStatus.BAD_REQUEST);
-  }
-
+  
   @ExceptionHandler({JDBCException.class})
   public ResponseEntity<?> handleJDBCException(
       HttpServletRequest request) {


### PR DESCRIPTION
fixes:
Caused by: java.lang.IllegalStateException: Ambiguous @ExceptionHandler method mapped for [class com.rackspace.salus.common.errors.RuntimeKafkaException]: {public org.springframework.http.ResponseEntity com.rackspace.salus.telemetry.presence_monitor.web.controller.RestExceptionHandler.handleKafkaExceptions(javax.servlet.http.HttpServletRequest), public org.springframework.http.ResponseEntity com.rackspace.salus.common.web.AbstractRestExceptionHandler.handleKafkaExceptions(javax.servlet.http.HttpServletRequest,java.lang.Exception)}
