### PR TITLE
Add common and enable role based views

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
     </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-common</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-resource-management</artifactId>
       <version>0.0.1-SNAPSHOT</version>
       <classifier>client</classifier>

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/PresenceMonitorApplication.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/PresenceMonitorApplication.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.telemetry.presence_monitor;
 
 import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
 import com.rackspace.salus.common.util.DumpConfigProperties;
+import com.rackspace.salus.common.web.EnableRoleBasedJsonViews;
 import com.rackspace.salus.telemetry.etcd.EnableEtcd;
 import com.rackspace.salus.telemetry.presence_monitor.types.PartitionSlice;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,6 +31,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableSalusKafkaMessaging
 @EnableScheduling
 @EnableEtcd
+@EnableRoleBasedJsonViews
 public class PresenceMonitorApplication {
 
 	@Bean

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/PresenceMonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/PresenceMonitorApiController.java
@@ -16,10 +16,8 @@
 
 package com.rackspace.salus.telemetry.presence_monitor.web.controller;
 
-import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.telemetry.etcd.services.WorkAllocationPartitionService;
 import com.rackspace.salus.telemetry.etcd.types.KeyRange;
-import com.rackspace.salus.common.web.View;
 import com.rackspace.salus.telemetry.presence_monitor.web.model.ChangePartitionsRequest;
 import com.rackspace.salus.telemetry.presence_monitor.web.model.SuccessResult;
 import java.util.List;

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/PresenceMonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/web/controller/PresenceMonitorApiController.java
@@ -19,7 +19,7 @@ package com.rackspace.salus.telemetry.presence_monitor.web.controller;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.telemetry.etcd.services.WorkAllocationPartitionService;
 import com.rackspace.salus.telemetry.etcd.types.KeyRange;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import com.rackspace.salus.telemetry.presence_monitor.web.model.ChangePartitionsRequest;
 import com.rackspace.salus.telemetry.presence_monitor.web.model.SuccessResult;
 import java.util.List;
@@ -46,13 +46,11 @@ public class PresenceMonitorApiController {
   }
 
   @GetMapping("/admin/presence-monitor/partitions")
-  @JsonView(View.Admin.class)
   public CompletableFuture<List<KeyRange>> presenceMonitorPartitions() {
     return workAllocationPartitionService.getPartitions();
   }
 
   @PutMapping("/admin/presence-monitor/partitions")
-  @JsonView(View.Admin.class)
   public CompletableFuture<SuccessResult> changePartitions(@RequestBody @Valid
                                                                ChangePartitionsRequest request)
       throws IllegalArgumentException {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,13 @@
 salus:
+  common:
+    roles:
+      role-to-view:
+        # An anonymous role is used for unauthenticated requests.
+        # i.e. internal service-to-service requests.
+        ROLE_ANONYMOUS: ADMIN
+        ROLE_CUSTOMER: PUBLIC
+        ROLE_EMPLOYEE: INTERNAL
+        ROLE_ENGINEER: ADMIN
   etcd:
     url: http://localhost:2479
   services:


### PR DESCRIPTION
# What

Add common dependency since it is no longer pulled in with `salus-telemetry-model`.

Enable role based json views instead of endpoint driven views.

# How

1. Add `@EnableRoleBasedJsonViews` to app
   * https://github.com/racker/salus-common/pull/49
1. Remove `@JsonView` annotations on api controllers
1. Add default role mappings to `application-dev.yml`

# Why

See https://github.com/racker/salus-common/pull/49

I almost didn't add the annotation to this app since it currently only has admin api endpoints so the views are irrelevant, but I put it in just to future proof things in case public api endpoints get added in the future.
