### PR TITLE
Add real role to access list

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,6 +8,7 @@ salus:
         ROLE_CUSTOMER: PUBLIC
         ROLE_EMPLOYEE: INTERNAL
         ROLE_ENGINEER: ADMIN
+        ROLE_IDENTITY_USER_ADMIN: PUBLIC
   etcd:
     url: http://localhost:2479
   services:


### PR DESCRIPTION
I'll be creating a PR that allows us to use our localdev services behind a repose instance using (prod or stage) Identity.

The `ROLE_IDENTITY_USER_ADMIN` is what the primary user on each tenant has.  By adding this to the list it means our default dev instance can work well enough with those users to test things locally.