### PR TITLE
Update metric metadata fields

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/MetricExporter.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/MetricExporter.java
@@ -25,10 +25,12 @@ import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 @Component
 @Slf4j

--- a/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/MetricRouter.java
+++ b/src/main/java/com/rackspace/salus/telemetry/presence_monitor/services/MetricRouter.java
@@ -80,7 +80,7 @@ public class MetricRouter {
         if (envoyId == null) {
             systemMetadata = Collections.emptyMap();
         } else {
-            systemMetadata = Collections.singletonMap("envoyId", envoyId);
+            systemMetadata = Collections.singletonMap("envoy_id", envoyId);
         }
         log.info("routing {}", resourceKey);
 

--- a/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/MetricRouterTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/presence_monitor/services/MetricRouterTest.java
@@ -88,7 +88,7 @@ public class MetricRouterTest {
 
       metricRouter = new MetricRouter(encoderFactory, kafkaEgress, client, objectMapper, new SimpleMeterRegistry(), timestampProvider);
         String expectedEntryString = "{\"active\": true, \"resourceInfo\":{\"resourceId\":\"os:LINUX\"," +
-                "\"labels\":{\"os\":\"LINUX\",\"arch\":\"X86_32\"},\"envoyId\":\"abcde\"," +
+                "\"labels\":{\"os\":\"LINUX\",\"arch\":\"X86_32\"},\"envoy_id\":\"abcde\"," +
                 "\"tenantId\":\"123456\",\"address\":\"host:1234\"}}";
         expectedEntry = objectMapper.readValue(expectedEntryString, PartitionSlice.ExpectedEntry.class);
 

--- a/src/test/resources/PresenceMonitorMetricRouterTest/testRouteMetric.json
+++ b/src/test/resources/PresenceMonitorMetricRouterTest/testRouteMetric.json
@@ -8,7 +8,7 @@
   },
   "monitoringSystem": "SALUS",
   "systemMetadata": {
-    "envoyId": "abcde"
+    "envoy_id": "abcde"
   },
   "metrics": [{
     "timestamp": "1970-01-01T00:00:00Z",


### PR DESCRIPTION
# Resolves

Related to https://jira.rax.io/browse/SALUS-1006

# What

Ensure system/device/metric metadata values are populated correctly.

# How

The values should be populated in the same format as the Ambassador is doing for all other metrics.

## How to test

Todo

# Why

To make metadata fields consistent across all metrics.

# TODO

## Test Failures

This PR cannot yet be merged because all tests fail.

`jetcd` is still using an older `testcontainers` version.  Even if we upgrade to `0.5.3` we still hit the problem and/or exclude the `testcontainers` dependency from `jetcd` and rely on the one from `salus-test` things still fail.

Additionally I did try using the `@RegisterExtension static final EtcdCluster etcd = new EtcdClusterExtension("test-etcd", 1);` fix referenced from https://github.com/etcd-io/jetcd/issues/742 but couldn't get that working either, so maybe @itzg 's fix in `etcd-adapter` is what will work best for us.

## Adding more fields
Once the test failures are resolved we can look into this.

We may need to introduce a `monitorType` metadata field for these metrics and potentially also include `selectorScope` and whatever else is required by Esper.

We'd need to duplicate the resourceLabels logic that ambassador does as well, right?